### PR TITLE
Fix issue with search where results with only 1 result aren't properly displayed

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,7 +341,7 @@ properties.parse(require('./lib/config').DEFAULT_CONF_FILE, {
                         range = ' between ' + t.toString().substring(4, 11) + t.toString().substring(16, 24) +
                             '-' + t2.toString().substring(4, 11) + t2.toString().substring(16, 24);
                     }
-                    if (body && typeof body === 'string') {
+                    if (_.isString(body)) {
                         body = body.split('\n');
                         body = body.map(function(x) {
                             try {
@@ -351,6 +351,8 @@ properties.parse(require('./lib/config').DEFAULT_CONF_FILE, {
                             }
                         });
                         body = _.compact(body);
+                    } else if (_.isPlainObject(body)) {
+                        body = [body];
                     }
 
                     utils.log('search finished: ' + (body ? body.length : 0) + ' line(s)' + (range || '') +


### PR DESCRIPTION
When the export API returns a single result (regardless of using the number parameter), the result is parsed into an object by utils.apiCall (called by utils.apiGet). This fix checks the results of the utils.apiGet and handles the result properly if it's an object.

I also opted to use Lodash's type checking functions in the places I was working in.