### PR TITLE
Fixing NPM Vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ logdna-cli.pkg
 logdna.gz
 version
 
-#Packages
+# Some extra data
+package-lock.json
+*~
+
+# Packages
 *.rpm
 *.deb

--- a/index.js
+++ b/index.js
@@ -374,7 +374,7 @@ checkElevated()
                         range = ' between ' + t.toString().substring(4, 11) + t.toString().substring(16, 24) +
                             '-' + t2.toString().substring(4, 11) + t2.toString().substring(16, 24);
                     }
-                    if (_.isString(body)) {
+                    if (typeof body === 'string') {
                         body = body.split('\n');
                         body = body.map((x) => {
                             try {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const program = require('commander');
 const properties = require('properties');
 const qs = require('querystring');
@@ -34,7 +33,7 @@ program
 properties.parse(require('./lib/config').DEFAULT_CONF_FILE, {
     path: true
 }, function(error, parsedConfig) {
-    const config = _.merge(require('./lib/config'), parsedConfig || {});
+    const config = Object.assign(require('./lib/config'), parsedConfig || {});
 
     utils.performUpgrade(config, function() {
         program.command('register [email] [key]')
@@ -101,7 +100,7 @@ properties.parse(require('./lib/config').DEFAULT_CONF_FILE, {
         program.command('ssologin')
             .description('Login to a LogDNA user account via Single Signon')
             .action(function() {
-                var token = _.random(800000000, 4000000000).toString(16);
+                var token = Math.floor((Math.random() * 4000000000) + 800000000).toString(16);
                 var pollTimeout;
 
                 utils.log('To sign in via SSO, use a web browser to open the page ' + config.SSO_URL + token);
@@ -216,9 +215,7 @@ properties.parse(require('./lib/config').DEFAULT_CONF_FILE, {
                     }
 
                     if (Array.isArray(data.p)) {
-                        _.each(data.p, function(line) {
-                            utils.renderLine(config, line, params);
-                        });
+                        data.p.forEach(line => utils.renderLine(config, line, params));
                     } else {
                         utils.renderLine(config, data.p, params);
                     }
@@ -336,14 +333,13 @@ properties.parse(require('./lib/config').DEFAULT_CONF_FILE, {
                     }
                     if (typeof body === 'string') {
                         body = body.split('\n');
-                        body = body.map(function(x) {
+                        body = body.map((x) => {
                             try {
                                 return JSON.parse(x);
                             } catch (err) {
                                 return 0;
                             }
-                        });
-                        body = _.compact(body);
+                        }).filter(element => element);
                     }
 
 
@@ -358,7 +354,7 @@ properties.parse(require('./lib/config').DEFAULT_CONF_FILE, {
 
                     var last_timestamp = new Date(body[0]._ts);
 
-                    _.each(body, function(line) {
+                    body.forEach((line) => {
                         t = new Date(line._ts);
                         if (options.preferHead && last_timestamp < t) {
                             last_timestamp = t;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const qs = require('querystring');
 const crypto = require('crypto');
 const os = require('os');
@@ -74,7 +73,7 @@ function apiCall(config, endpoint, method, params, callback) {
 
     } else {
         var hmacParams = authParams(config);
-        params = _.extend(params || {}, hmacParams);
+        params = Object.assign(params || {}, hmacParams);
         opts.query = params;
     }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "bufferutil": "^1.3.0",
     "commander": "^2.9.0",
-    "lodash": "^3.10.1",
     "properties": "^1.2.1",
     "request": "^2.88.0",
     "semver": "^5.1.0",
@@ -30,7 +29,7 @@
     "ws": "^1.0.1"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
+    "grunt": "^1.0.3",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-eslint": "^20.0.0",
     "grunt-exec": "^0.4.6",


### PR DESCRIPTION
Fixed:
- removed `lodash` and replaced with built-in functionalities;
- updated `grunt` version from `0.4.5` to `1.0.3`;
- now, `npm audit fix` (after `npm install` and having `package-lock.json`) says there is no vulnerability at all.

Tested on `Node v6.10.2` and `NPM v8.4.1`.