### PR TITLE
Add Usage Information to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,43 @@ grunt mac
 This will output the `pkg` file to the root of the repo. Signing will likely fail since we typically sign it with our Apple Developer key, but the package should still be usable, just unsigned.
 
 
+## Usage
+
+| Command | Description |
+| - | - |
+| `logdna register [email] [key]` | Register a new LogDNA account. `[key]` is optional and will autogenerate. |
+| `logdna ssologin` | Login to a LogDNA user account via single sign-on. |
+| `logdna login [email]` | Login to a LogDNA user account. |
+| `logdna tail [options] [query]` | Live tail with optional filtering. Options include `-h`, `-a`, `-l`, `-t` to filter by hosts, apps, levels or tags respectively. Run `logdna tail -h` to learn more. |
+| `logdna switch` | Switch between multiple accounts if your login has access to more than one. |
+| `logdna search [options] [query]` | Limited search functionality with optional filtering (beta). See `logdna search --help`. |
+| `logdna info` | Show current logged in user info. |
+| `logdna update` | Update CLI to latest version. |
+
+### Examples
+
+```sh
+# Register
+$ logdna register user@example.com
+$ logdna register user@example.com b7c0487cfa5fa7327c9a166c6418598d # use this if you were assigned an Ingestion Key
+
+# Login
+$ logdna login user@example.com
+
+# Tail
+$ logdna tail '("timed out" OR "connection refused") -request'
+$ logdna tail -a access.log 500
+$ logdna tail -l error,warn
+
+# Search
+$ logdna search "logdna cli" -a logdna.log -t tag1,tag2 -n 300
+$ logdna search "logdna" --from 1541100040931 --to 1541102940000
+
+# Other
+$ logdna info
+$ logdna update
+```
+
 ## Contributing
 
 Contributions are always welcome. See the [contributing guide](./CONTRIBUTING.md) to learn how you can help.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # logdna-cli
 
-The LogDNA CLI allows you to signup for a new account and tail your servers right from the command line.
+The LogDNA CLI allows you to sign up for a new account and tail your logs right from the command line.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ This will output the `pkg` file to the root of the repo. Signing will likely fai
 
 | Command | Description |
 | - | - |
-| `logdna register [email] [key]` | Register a new LogDNA account. `[key]` is optional and will autogenerate. |
-| `logdna ssologin` | Login to a LogDNA user account via single sign-on. |
-| `logdna login [email]` | Login to a LogDNA user account. |
-| `logdna tail [options] [query]` | Live tail with optional filtering. Options include `-h`, `-a`, `-l`, `-t` to filter by hosts, apps, levels or tags respectively. Run `logdna tail -h` to learn more. |
-| `logdna switch` | Switch between multiple accounts if your login has access to more than one. |
-| `logdna search [options] [query]` | Limited search functionality with optional filtering. See `logdna search --help`. |
-| `logdna info` | Show current logged in user info. |
-| `logdna update` | Update CLI to latest version. |
+| `logdna register [email]` | Register a new LogDNA account |
+| `logdna ssologin` | Log in to a LogDNA via single sign-on |
+| `logdna login [email]` | Log in to LogDNA |
+| `logdna tail [options] [query]` | Live tail with optional filtering. Options include `-h`, `-a`, `-l`, `-t` to filter by hosts, apps, levels or tags respectively. Run `logdna tail --help` to learn more. |
+| `logdna switch` | If your login has access to more than one account, this command allows you to switch between them |
+| `logdna search [options] [query]` | Basic search with optional filtering. Run `logdna search --help` for options. |
+| `logdna info` | Show current logged in user info |
+| `logdna update` | Update the CLI to the latest version |
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This will output the `pkg` file to the root of the repo. Signing will likely fai
 | `logdna login [email]` | Login to a LogDNA user account. |
 | `logdna tail [options] [query]` | Live tail with optional filtering. Options include `-h`, `-a`, `-l`, `-t` to filter by hosts, apps, levels or tags respectively. Run `logdna tail -h` to learn more. |
 | `logdna switch` | Switch between multiple accounts if your login has access to more than one. |
-| `logdna search [options] [query]` | Limited search functionality with optional filtering (beta). See `logdna search --help`. |
+| `logdna search [options] [query]` | Limited search functionality with optional filtering. See `logdna search --help`. |
 | `logdna info` | Show current logged in user info. |
 | `logdna update` | Update CLI to latest version. |
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ $ logdna search "logdna" --from 1541100040931 --to 1541102940000
 # Other
 $ logdna info
 $ logdna update
+
+# Switch organization
+$ logdna switch
+
+> 1: ACME (active)
+> 2: Strickland Propane
+> Choose account [1-2]:
 ```
 
 ## Contributing

--- a/index.js
+++ b/index.js
@@ -20,13 +20,12 @@ process.title = 'logdna';
 program._name = 'logdna';
 program
     .version(pkg.version, '-v, --version')
-    .usage('[commands] [options]\n\n  This CLI duplicates useful functionality of the LogDNA web app.')
-    // .description('This CLI duplicates useful functionality of the LogDNA web app.')
+    .usage('[commands] [options]\n\nThe LogDNA CLI allows you to signup for a new account and tail your servers right from the command line.')
     .on('--help', function() {
         utils.log('  Examples:');
         utils.log();
         utils.log('    $ logdna register user@example.com');
-        utils.log('    $ logdna register user@example.com b7c0487cfa5fa7327c9a166c6418598d    # use this if you were assigned an Ingestion Key');
+        utils.log('    $ logdna register user@example.com b7c0487cfa5fa7327c9a166c6418598d # use this if you were assigned an Ingestion Key');
         utils.log('    $ logdna tail \'("timed out" OR "connection refused") -request\'');
         utils.log('    $ logdna tail -a access.log 500');
         utils.log('    $ logdna tail -l error,warn');
@@ -71,9 +70,8 @@ checkElevated()
             if (error) utils.log(error);
         });
 
-        program.command('register [email] [key]')
-            .description('Register a new LogDNA account. [key] is optional and will autogenerate')
-            .action(function(email, key) {
+        program.command('register [email]')
+            .action(function(email) {
                 var nextstep = function(email) {
                     email = email.toLowerCase();
 
@@ -83,12 +81,9 @@ checkElevated()
                         input.required('Last name: ', function(lastname) {
                             input.required('Company/Organization: ', function(company) {
                                 input.done();
-
-                                key = (key || '').toLowerCase();
                                 utils.apiPost(config, 'register', {
                                     auth: false
                                     , email: email
-                                    , key: key
                                     , firstname: firstname
                                     , lastname: lastname
                                     , company: company
@@ -136,7 +131,7 @@ checkElevated()
             });
 
         program.command('ssologin')
-            .description('Login to a LogDNA user account via Single Signon')
+            .description('Log in to a LogDNA via single sign-on')
             .action(function() {
                 var token = Math.floor((Math.random() * 4000000000) + 800000000).toString(16);
                 var pollTimeout;
@@ -176,7 +171,7 @@ checkElevated()
             });
 
         program.command('login [email]')
-            .description('Login to a LogDNA user account')
+            .description('Log in to LogDNA')
             .action(function(email) {
                 var nextstep = function(email) {
                     input.hidden('Password: ', function(password) {
@@ -219,12 +214,12 @@ checkElevated()
             });
 
         program.command('tail [query]')
-            .description('Live tail with optional filtering. See \'logdna tail --help\'')
+            .description(`Live tail with optional filtering. Options include -h, -a, -l, -t to filter by hosts, apps, levels or tags respectively. Run logdna tail --help to learn more.`)
             .option('-h, --hosts <hosts>', 'Filter on hosts (separate by comma)')
             .option('-a, --apps <apps>', 'Filter on apps (separate by comma)')
             .option('-l, --levels <levels>', 'Filter on levels (separate by comma)')
             .option('-t, --tags <tags>', 'Filter on tags (separate by comma)')
-            .option('-j, --json', 'if true, output raw json', false)
+            .option('-j, --json', 'Output raw JSON', false)
             .action(function(query, options) {
                 var params = utils.authParams(config);
                 params.q = query || '';
@@ -286,7 +281,7 @@ checkElevated()
             });
 
         program.command('switch')
-            .description('Switch between multiple accounts if your login has access to more than one')
+            .description('If your login has access to more than one account, this command allows you to switch between them')
             .action(function(options) {
                 utils.apiGet(config, 'orgs', {}, function(error, response) {
                     if (error) {
@@ -442,7 +437,7 @@ checkElevated()
             });
 
         program.command('update')
-            .description('Update CLI to latest version')
+            .description('Update the CLI to the latest version')
             .action(function() {
                 utils.performUpgrade(config, true, function() {
                     utils.log('No update available. You have the latest version: ' + pkg.version);

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ checkElevated()
         });
 
         program.command('register [email]')
+            .description('Register a new LogDNA account')
             .action(function(email) {
                 var nextstep = function(email) {
                     email = email.toLowerCase();

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ process.title = 'logdna';
 program._name = 'logdna';
 program
     .version(pkg.version, '-v, --version')
-    .usage('[commands] [options]\n\nThe LogDNA CLI allows you to signup for a new account and tail your servers right from the command line.')
+    .usage('[commands] [options]\n\nThe LogDNA CLI allows you to sign up for a new account and tail your logs right from the command line.')
     .on('--help', function() {
         utils.log('  Examples:');
         utils.log();

--- a/index.js
+++ b/index.js
@@ -303,8 +303,10 @@ checkElevated()
                         input.done();
                         selection = parseInt(selection);
                         selection = selection - 1;
-
-                        if (selection >= response.length || selection < 0) return utils.log('Not a valid number.');
+                        
+                        if (isNaN(selection) || selection >= response.length || selection < 0) {
+                            return utils.log('Not a valid number.');
+                        }
 
                         config.account = response[selection].id;
                         config.servicekey = response[selection].servicekeys[0];
@@ -317,7 +319,7 @@ checkElevated()
             });
 
         program.command('search [query]')
-            .description('Limited search functionality with optional filtering (beta). See \'logdna search --help\'')
+            .description('Basic search with optional filtering. Run logdna search --help for options.')
             .option('-h, --hosts <hosts>', 'Filter on hosts (separate by comma)')
             .option('-a, --apps <apps>', 'Filter on apps (separate by comma)')
             .option('-l, --levels <levels>', 'Filter on levels (separate by comma)')
@@ -327,7 +329,7 @@ checkElevated()
             .option('--next', 'Get next chunk of lines (after last search). This is a convenience wrapper around the --from and --to parameters.')
             .option('--from <from>', 'Unix timestamp of beginning of search timeframe.')
             .option('--to <to>', 'Unix timestamp of end of search timeframe.')
-            .option('-j, --json', 'if true, output raw json', false)
+            .option('-j, --json', 'Output raw JSON', false)
             .action(function(query, options) {
                 var params = {
                     q: query || ''


### PR DESCRIPTION
Add the following information to readme:


## Usage

| Command | Description |
| - | - |
| `logdna register [email]` | Register a new LogDNA account |
| `logdna ssologin` | Log in to a LogDNA via single sign-on |
| `logdna login [email]` | Log in to LogDNA |
| `logdna tail [options] [query]` | Live tail with optional filtering. Options include `-h`, `-a`, `-l`, `-t` to filter by hosts, apps, levels or tags respectively. Run `logdna tail --help` to learn more. |
| `logdna switch` | If your login has access to more than one account, this command allows you to switch between them |
| `logdna search [options] [query]` | Basic search with optional filtering. Run `logdna search --help` for options. |
| `logdna info` | Show current logged in user info |
| `logdna update` | Update the CLI to the latest version |

### Examples

```sh
# Register
$ logdna register user@example.com
$ logdna register user@example.com b7c0487cfa5fa7327c9a166c6418598d # use this if you were assigned an Ingestion Key

# Login
$ logdna login user@example.com

# Tail
$ logdna tail '("timed out" OR "connection refused") -request'
$ logdna tail -a access.log 500
$ logdna tail -l error,warn

# Search
$ logdna search "logdna cli" -a logdna.log -t tag1,tag2 -n 300
$ logdna search "logdna" --from 1541100040931 --to 1541102940000

# Other
$ logdna info
$ logdna update

# Switch organization
$ logdna switch

> 1: ACME (active)
> 2: Strickland Propane
> Choose account [1-2]:
```