### PR TITLE
Don't show error if the configuration file does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,8 @@ program
     });
 
 properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) => {
-    if (err) {
-        return utils.log('Unable to read the configuration file.');
+    if (err && err.code !== 'ENOENT') {
+        return utils.log('Unable to read the configuration file: ' + err.code);
     }
     config = Object.assign(config, parsedConfig || {});
 


### PR DESCRIPTION
* Fixes `Unable to read the configuration file` error on the first run.
* Show error code in the error message.

Before:

```
$ logdna tail
Unable to read the configuration file.
```

After:

```
$ logdna tail
Please login first. Type 'logdna login' or 'logdna --help' for more info.
```