### PR TITLE
Write informational output to stderr for tail and search

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,22 +210,22 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
 
             ws.on('open', function open() {
                 // Informational output for tail written to stderr to not interfere with actual data
-                utils.error('tail started. hosts: ' + (options.hosts || 'all') +
+                utils.log('tail started. hosts: ' + (options.hosts || 'all') +
                     '. apps: ' + (options.apps || 'all') +
                     '. tags: ' + (options.tags || 'all') +
                     '. levels: ' + (options.levels || 'all') +
-                    '. query: ' + (query || 'none'));
+                    '. query: ' + (query || 'none'), null, 'error');
             });
 
             ws.on('reconnecting', function(num) {
-                utils.error('tail reconnect attmpt #' + num + '...');
+                utils.log('tail reconnect attmpt #' + num + '...', null, 'error');
             });
 
             ws.on('message', function(data) {
                 try {
                     data = JSON.parse(data);
                 } catch (err) {
-                    return utils.error('Malformed line: ' + err);
+                    return utils.log('Malformed line: ' + err, null, 'error');
                 }
 
                 const account = data.e;
@@ -243,14 +243,14 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
                 err = err.toString();
                 if (err.indexOf('401') > -1) {
                     // invalid token
-                    utils.error('Access token invalid. If you created or changed your password recently, please \'logdna login\' or \'logdna ssologin\' again. Type \'logdna --help\' for more info.');
+                    utils.log('Access token invalid. If you created or changed your password recently, please \'logdna login\' or \'logdna ssologin\' again. Type \'logdna --help\' for more info.', null, 'error');
                     return process.exit();
                 }
-                utils.error('Error: ' + err);
+                utils.log('Error: ' + err, null, 'error');
             });
 
             ws.on('close', function() {
-                utils.error('tail lost connection');
+                utils.log('tail lost connection', null, 'error');
             });
         });
 
@@ -352,7 +352,7 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
             var t, t2, range;
 
             utils.apiGet(modifiedconfig, 'v1/export', params, function(error, body) {
-                if (error) return utils.error(error);
+                if (error) return utils.log(error, null, 'error');
                 if (body && body.range && body.range.from && body.range.to) {
                     t = new Date(body.range.from);
                     t2 = new Date(body.range.to);
@@ -370,17 +370,17 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
                     }).filter(element => element);
                 }
                 // Informational output for search written to stderr to not interfere with actual data
-                utils.error('search finished: ' + (body ? body.length : 0) + ' line(s)' + (range || '') +
+                utils.log('search finished: ' + (body ? body.length : 0) + ' line(s)' + (range || '') +
                     '. hosts: ' + (options.hosts || 'all') +
                     '. apps: ' + (options.apps || 'all') +
                     '. levels: ' + (options.levels || 'all') +
                     '. tags: ' + (options.tags || 'all') +
-                    '. query: ' + (query || 'none'));
+                    '. query: ' + (query || 'none'), null, 'error');
 
 
                 const lines = [].concat(body);
                 if (!lines.length) {
-                    return utils.error('Query returned no lines.');
+                    return utils.log('Query returned no lines.', null, 'error');
                 }
 
                 let last_timestamp = new Date(lines[0]._ts);
@@ -397,7 +397,7 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
 
                 config.last_timestamp = last_timestamp.toJSON();
                 utils.saveConfig(config, function(error, success) {
-                    if (error) return utils.error(error);
+                    if (error) return utils.log(error, null, 'error');
                 });
             });
         });

--- a/index.js
+++ b/index.js
@@ -209,7 +209,8 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
             var ws = new WebSocket((config.LOGDNA_APISSL ? 'https://' : 'http://') + config.LOGDNA_TAILHOST + '/ws/tail?' + qs.stringify(params));
 
             ws.on('open', function open() {
-                utils.log('tail started. hosts: ' + (options.hosts || 'all') +
+                // Informational output for tail written to stderr to not interfere with actual data
+                console.error('tail started. hosts: ' + (options.hosts || 'all') +
                     '. apps: ' + (options.apps || 'all') +
                     '. tags: ' + (options.tags || 'all') +
                     '. levels: ' + (options.levels || 'all') +
@@ -217,14 +218,14 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
             });
 
             ws.on('reconnecting', function(num) {
-                utils.log('tail reconnect attmpt #' + num + '...');
+                console.error('tail reconnect attmpt #' + num + '...');
             });
 
             ws.on('message', function(data) {
                 try {
                     data = JSON.parse(data);
                 } catch (err) {
-                    return utils.log('Malformed line: ' + err);
+                    return console.error('Malformed line: ' + err);
                 }
 
                 const account = data.e;
@@ -242,15 +243,14 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
                 err = err.toString();
                 if (err.indexOf('401') > -1) {
                     // invalid token
-                    utils.log('Access token invalid. If you created or changed your password recently, please \'logdna login\' or \'logdna ssologin\' again. Type \'logdna --help\' for more info.');
+                    console.error('Access token invalid. If you created or changed your password recently, please \'logdna login\' or \'logdna ssologin\' again. Type \'logdna --help\' for more info.');
                     return process.exit();
                 }
-
-                utils.log('Error: ' + err);
+                console.error('Error: ' + err);
             });
 
             ws.on('close', function() {
-                utils.log('tail lost connection');
+                console.error('tail lost connection');
             });
         });
 
@@ -369,8 +369,8 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
                         }
                     }).filter(element => element);
                 }
-
-                utils.log('search finished: ' + (body ? body.length : 0) + ' line(s)' + (range || '') +
+                // Informational output for search written to stderr to not interfere with actual data
+                console.error('search finished: ' + (body ? body.length : 0) + ' line(s)' + (range || '') +
                     '. hosts: ' + (options.hosts || 'all') +
                     '. apps: ' + (options.apps || 'all') +
                     '. levels: ' + (options.levels || 'all') +
@@ -380,7 +380,7 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
 
                 const lines = [].concat(body);
                 if (!lines.length) {
-                    return utils.log('Query returned no lines.');
+                    return console.error('Query returned no lines.');
                 }
 
                 let last_timestamp = new Date(lines[0]._ts);
@@ -397,7 +397,7 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
 
                 config.last_timestamp = last_timestamp.toJSON();
                 utils.saveConfig(config, function(error, success) {
-                    if (error) return utils.log(error);
+                    if (error) return console.error(error);
                 });
             });
         });

--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
 
             ws.on('open', function open() {
                 // Informational output for tail written to stderr to not interfere with actual data
-                console.error('tail started. hosts: ' + (options.hosts || 'all') +
+                utils.error('tail started. hosts: ' + (options.hosts || 'all') +
                     '. apps: ' + (options.apps || 'all') +
                     '. tags: ' + (options.tags || 'all') +
                     '. levels: ' + (options.levels || 'all') +
@@ -218,14 +218,14 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
             });
 
             ws.on('reconnecting', function(num) {
-                console.error('tail reconnect attmpt #' + num + '...');
+                utils.error('tail reconnect attmpt #' + num + '...');
             });
 
             ws.on('message', function(data) {
                 try {
                     data = JSON.parse(data);
                 } catch (err) {
-                    return console.error('Malformed line: ' + err);
+                    return utils.error('Malformed line: ' + err);
                 }
 
                 const account = data.e;
@@ -243,14 +243,14 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
                 err = err.toString();
                 if (err.indexOf('401') > -1) {
                     // invalid token
-                    console.error('Access token invalid. If you created or changed your password recently, please \'logdna login\' or \'logdna ssologin\' again. Type \'logdna --help\' for more info.');
+                    utils.error('Access token invalid. If you created or changed your password recently, please \'logdna login\' or \'logdna ssologin\' again. Type \'logdna --help\' for more info.');
                     return process.exit();
                 }
-                console.error('Error: ' + err);
+                utils.error('Error: ' + err);
             });
 
             ws.on('close', function() {
-                console.error('tail lost connection');
+                utils.error('tail lost connection');
             });
         });
 
@@ -352,7 +352,7 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
             var t, t2, range;
 
             utils.apiGet(modifiedconfig, 'v1/export', params, function(error, body) {
-                if (error) return utils.log(error);
+                if (error) return utils.error(error);
                 if (body && body.range && body.range.from && body.range.to) {
                     t = new Date(body.range.from);
                     t2 = new Date(body.range.to);
@@ -370,7 +370,7 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
                     }).filter(element => element);
                 }
                 // Informational output for search written to stderr to not interfere with actual data
-                console.error('search finished: ' + (body ? body.length : 0) + ' line(s)' + (range || '') +
+                utils.error('search finished: ' + (body ? body.length : 0) + ' line(s)' + (range || '') +
                     '. hosts: ' + (options.hosts || 'all') +
                     '. apps: ' + (options.apps || 'all') +
                     '. levels: ' + (options.levels || 'all') +
@@ -380,7 +380,7 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
 
                 const lines = [].concat(body);
                 if (!lines.length) {
-                    return console.error('Query returned no lines.');
+                    return utils.error('Query returned no lines.');
                 }
 
                 let last_timestamp = new Date(lines[0]._ts);
@@ -397,7 +397,7 @@ properties.parse(config.DEFAULT_CONF_FILE, { path: true }, (err, parsedConfig) =
 
                 config.last_timestamp = last_timestamp.toJSON();
                 utils.saveConfig(config, function(error, success) {
-                    if (error) return console.error(error);
+                    if (error) return utils.error(error);
                 });
             });
         });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -105,7 +105,7 @@ function apiCall(config, endpoint, method, params, callback) {
                 return callback('Access token invalid. If you created or changed your password recently, ' +
                                 'please run \'logdna login\' again. Type \'logdna --help\' for more info.');
             }
-            return callback('Error: ' + body.error || error);
+            return callback('Error: ' + error || body.error);
         }
         callback(null, body);
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,22 +21,13 @@ const saveConfig = function(config, callback) {
     });
 };
 
-const error = function(msg, config) {
+const log = function(msg, config, level) {
     try {
-        console.error(msg || '');
-    } catch (e) {
-        if (config) {
-            saveConfig(config, (error, result) => {
-                if (error) console.error(error);
-                return process.exit(0);
-            });
+        if (level === 'error') {
+            console.error(msg || '');
+        } else {
+            console.log(msg || '');
         }
-    }
-}
-
-const log = function(msg, config) {
-    try {
-        console.log(msg || '');
     } catch (e) {
         if (config) {
             saveConfig(config, (error, result) => {
@@ -221,7 +212,6 @@ const performUpgrade = function(config, force, callback) {
 };
 
 exports.saveConfig = saveConfig;
-exports.error = error;
 exports.log = log;
 exports.apiGet = apiGet;
 exports.apiPost = apiPost;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,19 @@ const saveConfig = function(config, callback) {
     });
 };
 
+const error = function(msg, config) {
+    try {
+        console.error(msg || '');
+    } catch (e) {
+        if (config) {
+            saveConfig(config, (error, result) => {
+                if (error) console.error(error);
+                return process.exit(0);
+            });
+        }
+    }
+}
+
 const log = function(msg, config) {
     try {
         console.log(msg || '');
@@ -208,6 +221,7 @@ const performUpgrade = function(config, force, callback) {
 };
 
 exports.saveConfig = saveConfig;
+exports.error = error;
 exports.log = log;
 exports.apiGet = apiGet;
 exports.apiPost = apiPost;


### PR DESCRIPTION
Plaintext summary lines, 'no result' lines, and internal errors are sent to stderr to not interfere with actual data for tail and search.
This also fixes https://github.com/logdna/logdna-cli/issues/42 where piping output from tail and search under json flag would break due to summary line.

Before 
```
logdna search "docker" -j | jq
parse error: Invalid numeric literal at line 1, column 7
```

After 
```
logdna search "docker" -j | jq
search finished: 5000 line(s). hosts: all. apps: all. levels: all. tags: all. query: docker
{
  ...json output
}
```