### PR TITLE
bump: bump version to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v2.0.0] - 2020-05-14
+## [v2.0.0] - 2020-05-21
 ### Fixed
 - Fix `Cannot read property 'statusCode' of undefined` when updating [#40](https://github.com/logdna/logdna-cli/pull/40)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The LogDNA CLI allows you to sign up for a new account and tail your logs right from the command line.
 
+## Deprecation Notice: LogDNA CLI deprecates supporting CentOS 6 and Debian 8 as of v2.
+
 ## Getting Started
 
 ### macOS
@@ -43,7 +45,7 @@ Follow these quick instructions to run the LogDNA CLI from source:
 ```
 git clone https://github.com/logdna/logdna-cli.git
 cd logdna-cli
-npm install
+npm install --production
 
 # help
 node index.js --help
@@ -52,65 +54,6 @@ node index.js --help
 node index.js login
 node index.js ssologin
 ```
-
-## Building Binaries
-
-To build the cli, ensure you have [nexe](https://www.npmjs.com/package/nexe) installed. This packages the LogDNA CLI as a native executable with the node.js runtime bundled. This will automatically build the runtime from source.
-
-### Linux
-
-Ensure you have a native C++ compiler installed.
-
-### Windows
-
-Ensure you have Visual Studio 2015 or newer installed.
-
-### macOS
-
-Ensure you have Xcode 7 or newer installed.
-
-### Creating the binary
-
-To start the build:
-
-```
-grunt build
-```
-
-This takes a bit of time and will output a binary at `./logdna` (or `.\logdna.exe` if on Windows). For the initial build, majority of time will be spent building node.js. Subsequent builds will be much faster as node.js would've already been built.
-
-## Packaging Binaries
-
-### Linux
-
-```
-sudo gem install fpm
-sudo yum install rpm-build createrepo
-sudo yum --enablerepo=epel install dpkg-devel dpkg-dev
-grunt linux
-```
-
-This will output the `deb` and `yum` files to the root of the repo.
-
-### Windows
-
-Install [chocolatey](https://chocolatey.org). Then do:
-
-```
-grunt windows
-```
-
-This will output the chocolatey package under `.\.builds\windows`.
-
-### macOS
-
-```
-gem install fpm
-grunt mac
-```
-
-This will output the `pkg` file to the root of the repo. Signing will likely fail since we typically sign it with our Apple Developer key, but the package should still be usable, just unsigned.
-
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logdna-cli",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "description": "LogDNA CLI",
   "main": "index.js",
   "scripts": {

--- a/scripts/logdna.nuspec
+++ b/scripts/logdna.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>logdna</id>
     <title>LogDNA CLI for Windows</title>
-    <version>1.4.1</version>
+    <version>2.0.0</version>
     <authors>sedouard,leeliu</authors>
     <owners>leeliu</owners>
     <summary>LogDNA CLI for Windows</summary>


### PR DESCRIPTION
- Update `README` by adding `Deprecation Notice` and removing `Building Binaries` and `Packaging`
- Bump version in `package.json` and `scripts/logdna.nuspec`
- Update `CHANGELOG`