### PR TITLE
feat(tail): Include websocket pings to keep socket up behind proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Add periodic websocket pings when connected to livetail. This adds support for aggresive proxies that disconnect idle connections
 - Natural Language Processing on timestamps using [Chrono](https://github.com/wanasit/chrono).  Introduction of --timeframe option for search.  Addition of developer logging via LogDNA for troubleshooting.
 - Changed CONTRIBUTING.md to reflect "fork-and-PR" process
 

--- a/lib/logdna-websocket.js
+++ b/lib/logdna-websocket.js
@@ -17,6 +17,7 @@ function LDWebSocket(address, protocols, options) {
     this.reconnectionDelay = options.reconnectionDelay || 1000;
     this.reconnectionDelayMax = options.reconnectionDelayMax || 5000;
     this.connectTimeout = options.connectTimeout || 20000;
+    this.pingInterval = options.pingInterval || 30000;
     this.connectAttempt = 0;
     this.connected = false;
     this.reconnectionFactor = 1.5;
@@ -46,6 +47,7 @@ LDWebSocket.prototype.open = function() {
     this.ws.on('pong', this.onpong.bind(this));
 
     this.connectTimeoutHandler = setTimeout(function() { this.reconnect(); }.bind(this), this.connectTimeout);
+    this.pingIntervalHandler = setInterval(this.ws.ping.bind(this.ws), this.pingInterval);
 };
 
 LDWebSocket.prototype.onopen = function() {
@@ -82,6 +84,7 @@ LDWebSocket.prototype.onpong = function(data, flags) {
 LDWebSocket.prototype.reconnect = function() {
     clearTimeout(this.connectTimeoutHandler);
     clearTimeout(this.reconnectTimeoutHandler);
+    clearInterval(this.pingIntervalHandler);
     if (!this.reconnection) return;
 
     if (this.ws) {


### PR DESCRIPTION
When the remote livetail service is behind an aggresive proxy, it is
likely that idle connections will be terminated. While normal behavior,
it can make for a less than ideal experience you have the connection
recycling every minute.

This adds a ping interval to send ping packets as described in the
websocket spec to keep the socket connection from being disconnected
while idle

Ref: LOG-11362